### PR TITLE
Make region explicit in API access

### DIFF
--- a/apps/sample-nextjs-basic-auth/util/xata.ts
+++ b/apps/sample-nextjs-basic-auth/util/xata.ts
@@ -41,7 +41,7 @@ export type DatabaseSchema = {
 const DatabaseClient = buildClient();
 
 const defaultOptions = {
-  databaseURL: "https://xata_examples-hf8grf.xata.sh/db/nextjs_basic_auth",
+  databaseURL: "https://xata_examples-hf8grf.eu-west-1.xata.sh/db/nextjs_basic_auth",
 };
 
 export class XataClient extends DatabaseClient<DatabaseSchema> {

--- a/apps/starter-remix-netlify/app/lib/xata.codegen.server.ts
+++ b/apps/starter-remix-netlify/app/lib/xata.codegen.server.ts
@@ -25,7 +25,7 @@ export type RemixWithXataExampleRecord = RemixWithXataExample & XataRecord
 const DatabaseClient = buildClient()
 
 const defaultOptions = {
-  databaseURL: 'https://xata_examples-hf8grf.xata.sh/db/remix_minimal',
+  databaseURL: 'https://xata_examples-hf8grf.eu-west-1.xata.sh/db/remix_minimal',
 }
 
 export class XataClient extends DatabaseClient<SchemaTables> {

--- a/apps/starter-vercel-serverless-functions/package.json
+++ b/apps/starter-vercel-serverless-functions/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vc dev",
     "xata:codegen": "xata codegen",
-    "postinstall": "npx @xata.io/cli codegen --db=\"https://xata_examples-hf8grf.xata.sh/db/marvel\" -b=\"main\" -o=\"_lib/xata.codegen.ts\""
+    "postinstall": "npx @xata.io/cli codegen --db=\"https://xata_examples-hf8grf.eu-west-1.xata.sh/db/marvel\" -b=\"main\" -o=\"_lib/xata.codegen.ts\""
   },
   "devDependencies": {
     "@vercel/node": "2.5.26",


### PR DESCRIPTION
Old API URLs are still working but have been deprecated in favour of the explict region in the URL