### PR TITLE
fix xata cli links

### DIFF
--- a/apps/sample-next-auth-app/README.md
+++ b/apps/sample-next-auth-app/README.md
@@ -19,7 +19,7 @@ npx degit xataio/examples/apps/sample-next-auth-app my-awesome-app
 
 ## Initialize your Database
 
-In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/cli/getting-started).
+In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/getting-started/cli).
 
 > 💡 Having it globally will speed-up linking your project via `xata init`, just make sure you have it up-to-date so it generates the SDK with compatible types.
 

--- a/apps/sample-next-auth-pages/README.md
+++ b/apps/sample-next-auth-pages/README.md
@@ -19,7 +19,7 @@ npx degit xataio/examples/apps/sample-next-auth-pages my-awesome-app
 
 ## Initialize your Database
 
-In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/cli/getting-started).
+In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/getting-started/cli).
 
 > 💡 Having it globally will speed-up linking your project via `xata init`, just make sure you have it up-to-date so it generates the SDK with compatible types.
 

--- a/apps/sample-nextjs-basic-auth/README.md
+++ b/apps/sample-nextjs-basic-auth/README.md
@@ -10,7 +10,7 @@ Copy the code from this repository. Or use it as a Next.js starter:
 npx create-next-app -e https://github.com/xataio/examples/apps/sample-nextjs-basic-auth
 ```
 
-We recomend to have the [Xata CLI](https://xata.io/docs/cli/getting-started) installed globally to make your usage more ergonomic:
+We recomend to have the [Xata CLI](https://xata.io/docs/getting-started/cli) installed globally to make your usage more ergonomic:
 
 ```
 npm i -g @xata.io/cli@latest

--- a/docs/starter_readme.template.md
+++ b/docs/starter_readme.template.md
@@ -29,7 +29,7 @@ npx degit xataio/examples/apps/<name-of-app> my-xata-app
 
 ## Initialize your Database 🐣
 
-In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/cli/getting-started).
+In order to connect to a workspace, a `XATA_API_TOKEN` and a database URL. One of way of setting it up is running the [Xata CLI](https://xata.io/docs/getting-started/cli).
 
 > 💡 Having it globally will speed-up linking your project via `xata init`, just make sure you have it up-to-date so it generates the SDK with compatible types.
 


### PR DESCRIPTION
Fix links to [Xata CLI](https://xata.io/docs/getting-started/cli)