### PR TITLE
Update [slug].astro

### DIFF
--- a/apps/getting-started-astro/src/pages/posts/[slug].astro
+++ b/apps/getting-started-astro/src/pages/posts/[slug].astro
@@ -1,26 +1,15 @@
 ---
-import MainLayout from '../../layouts/main.astro'
+import MainLayout from "../../layouts/main.astro";
 
-import { XataClient } from '../../xata';
+import { XataClient } from "../../xata";
 
-export async function getStaticPaths() {
-  const xata = new XataClient({ 
-	  apiKey: import.meta.env.XATA_API_KEY,
-	  branch: import.meta.env.XATA_BRANCH
-  });
-  const posts = await xata.db.Posts.getAll();
+const { slug } = Astro.params;
 
-  const routes = posts.map(({ slug, title, description, pubDate }) => {
-    return {
-      params: { slug },
-      props: { title, description, pubDate },
-    };
-  });
-
-  return routes;
-}
-
-const post = Astro.props;
+const xata = new XataClient({
+  apiKey: import.meta.env.XATA_API_KEY,
+  branch: import.meta.env.XATA_BRANCH,
+});
+const post = await xata.db.Posts.filter({ slug: slug }).getFirstOrThrow();
 ---
 
 <MainLayout title={post.title}>


### PR DESCRIPTION
Because SSR pages can’t use getStaticPaths(), they can’t receive props. https://docs.astro.build/en/guides/routing/#modifying-the-slug-example-for-ssr

<!--
Remember to mark it as an issue fix or part of
-->

Fixes #1252

<!-- Part of  #{issue_number} -->

<!--
If this is a new Sample, double-check if you used the ./docs/readme_template.md
-->

<!--
Remember to explain changes and how to run code changes locally.
Mark the checkboxes as relevant (remove the ones that aren't).
-->

- [x] Tested in different browsers (at least Chromium, Safari, and Firefox).
- [x] Added appropriate tests to avoid future regressions.
- [x] Addressed changes to documentation. https://github.com/xataio/mdx-docs/pull/379
